### PR TITLE
Update `package.json`s directly (avoid `npm version`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "test": "jest"
   },
   "dependencies": {
+    "detect-indent": "^6.0.0",
+    "detect-newline": "^3.1.0",
     "release-it": "^13.3.1",
     "semver": "^7.1.3",
     "url-join": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1639,7 +1639,12 @@ detect-file@^1.0.0:
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
   integrity sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=
 
-detect-newline@^3.0.0:
+detect-indent@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.0.0.tgz#0abd0f549f69fc6659a254fe96786186b6f528fd"
+  integrity sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==
+
+detect-newline@^3.0.0, detect-newline@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==


### PR DESCRIPTION
At the moment this is just an internal refactor (nothing external changes here), but a future change will leverage this and it seemed better to break it out into a separate PR.