### PR TITLE
Ensure OTP prompting works correctly

### DIFF
--- a/__tests__/plugin-test.js
+++ b/__tests__/plugin-test.js
@@ -64,10 +64,14 @@ function buildPlugin(config = {}, _Plugin = TestPlugin) {
     let response = commandResponses[relativeRoot] && commandResponses[relativeRoot][command];
 
     if (response) {
+      if (Array.isArray(response)) {
+        response = response.shift();
+      }
+
       if (typeof response === 'string') {
         return Promise.resolve(response);
       } else if (typeof response === 'object' && response !== null && response.reject === true) {
-        return Promise.reject(response.value);
+        return Promise.reject(new Error(response.value));
       }
     }
   };

--- a/__tests__/plugin-test.js
+++ b/__tests__/plugin-test.js
@@ -405,6 +405,61 @@ describe('release-it-yarn-workspaces', () => {
         ]
       `);
     });
+
+    it('when publishing rejects requiring a one time password', async () => {
+      let plugin = buildPlugin();
+
+      plugin.commandResponses['packages/bar'] = {
+        'npm publish . --tag latest': [
+          {
+            reject: true,
+            value: 'This operation requires a one-time password',
+          },
+        ],
+      };
+
+      plugin.promptResponses['packages/bar'] = {
+        otp: '123456',
+      };
+
+      await runTasks(plugin);
+
+      expect(plugin.commands).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "command": "npm ping --registry https://registry.npmjs.org",
+            "options": Object {},
+            "relativeRoot": "",
+          },
+          Object {
+            "command": "npm whoami --registry https://registry.npmjs.org",
+            "options": Object {},
+            "relativeRoot": "",
+          },
+          Object {
+            "command": "npm publish . --tag latest",
+            "options": Object {
+              "write": false,
+            },
+            "relativeRoot": "packages/bar",
+          },
+          Object {
+            "command": "npm publish . --tag latest --otp 123456",
+            "options": Object {
+              "write": false,
+            },
+            "relativeRoot": "packages/bar",
+          },
+          Object {
+            "command": "npm publish . --tag latest --otp 123456",
+            "options": Object {
+              "write": false,
+            },
+            "relativeRoot": "packages/foo",
+          },
+        ]
+      `);
+    });
   });
 
   describe('format publish output', () => {

--- a/__tests__/plugin-test.js
+++ b/__tests__/plugin-test.js
@@ -135,14 +135,14 @@ describe('release-it-yarn-workspaces', () => {
             "relativeRoot": "",
           },
           Object {
-            "command": "npm publish . --tag latest  ",
+            "command": "npm publish . --tag latest",
             "options": Object {
               "write": false,
             },
             "relativeRoot": "packages/bar",
           },
           Object {
-            "command": "npm publish . --tag latest  ",
+            "command": "npm publish . --tag latest",
             "options": Object {
               "write": false,
             },
@@ -255,14 +255,14 @@ describe('release-it-yarn-workspaces', () => {
             "relativeRoot": "",
           },
           Object {
-            "command": "npm publish . --tag latest  ",
+            "command": "npm publish . --tag latest",
             "options": Object {
               "write": false,
             },
             "relativeRoot": "dist/packages/qux",
           },
           Object {
-            "command": "npm publish . --tag latest  ",
+            "command": "npm publish . --tag latest",
             "options": Object {
               "write": false,
             },
@@ -301,14 +301,14 @@ describe('release-it-yarn-workspaces', () => {
             "relativeRoot": "",
           },
           Object {
-            "command": "npm publish . --tag foo  ",
+            "command": "npm publish . --tag foo",
             "options": Object {
               "write": false,
             },
             "relativeRoot": "packages/bar",
           },
           Object {
-            "command": "npm publish . --tag foo  ",
+            "command": "npm publish . --tag foo",
             "options": Object {
               "write": false,
             },
@@ -326,14 +326,14 @@ describe('release-it-yarn-workspaces', () => {
       expect(plugin.commands).toMatchInlineSnapshot(`
         Array [
           Object {
-            "command": "npm publish . --tag latest  ",
+            "command": "npm publish . --tag latest",
             "options": Object {
               "write": false,
             },
             "relativeRoot": "packages/bar",
           },
           Object {
-            "command": "npm publish . --tag latest  ",
+            "command": "npm publish . --tag latest",
             "options": Object {
               "write": false,
             },
@@ -363,14 +363,14 @@ describe('release-it-yarn-workspaces', () => {
             "relativeRoot": "",
           },
           Object {
-            "command": "npm publish . --tag beta  ",
+            "command": "npm publish . --tag beta",
             "options": Object {
               "write": false,
             },
             "relativeRoot": "packages/bar",
           },
           Object {
-            "command": "npm publish . --tag beta  ",
+            "command": "npm publish . --tag beta",
             "options": Object {
               "write": false,
             },

--- a/index.js
+++ b/index.js
@@ -184,11 +184,17 @@ module.exports = class YarnWorkspacesPlugin extends Plugin {
   async release() {
     if (this.options.publish === false) return;
 
+    // creating a stable object that is shared across all package publishes
+    // this ensures that we don't accidentally prompt multiple times (e.g. once
+    // per package) due to loosing the otp value after each `this.publish` call
+    const otp = {
+      value: this.options.otp,
+    };
+
     const tag = this.getContext('distTag');
-    const otpCallback = this.global.isCI ? null : (task) => this.step({ prompt: 'otp', task });
     const task = async () => {
       await this.eachWorkspace(async (workspaceInfo) => {
-        await this.publish({ tag, workspaceInfo, otpCallback });
+        await this.publish({ tag, workspaceInfo, otp });
       });
     };
 
@@ -274,9 +280,9 @@ module.exports = class YarnWorkspacesPlugin extends Plugin {
     return this.getContext('publishConfig.registry') || NPM_DEFAULT_REGISTRY;
   }
 
-  async publish({ tag, workspaceInfo, otp, otpCallback } = {}) {
-    const otpArg = otp ? `--otp ${otp}` : '';
-    const dryRunArg = this.global.isDryRun ? '--dry-run' : '';
+  async publish({ tag, workspaceInfo, otp } = {}) {
+    const otpArg = otp.value ? ` --otp ${otp.value}` : '';
+    const dryRunArg = this.global.isDryRun ? ' --dry-run' : '';
 
     if (workspaceInfo.isPrivate) {
       this.log.warn(`${workspaceInfo.name}: Skip publish (package is private)`);
@@ -284,7 +290,7 @@ module.exports = class YarnWorkspacesPlugin extends Plugin {
     }
 
     try {
-      await this.exec(`npm publish . --tag ${tag} ${otpArg} ${dryRunArg}`, {
+      await this.exec(`npm publish . --tag ${tag}${otpArg}${dryRunArg}`, {
         options,
       });
 
@@ -292,12 +298,15 @@ module.exports = class YarnWorkspacesPlugin extends Plugin {
     } catch (err) {
       this.debug(err);
       if (/one-time pass/.test(err)) {
-        if (otp != null) {
+        if (otp.value != null) {
           this.log.warn('The provided OTP is incorrect or has expired.');
         }
-        if (otpCallback) {
-          return otpCallback((otp) => this.publish({ workspaceInfo, tag, otp, otpCallback }));
-        }
+
+        await this.step({ prompt: 'otp', task(newOtp) {
+          otp.value = newOtp;
+        }});
+
+        return await this.publish(...arguments);
       }
       throw err;
     }

--- a/index.js
+++ b/index.js
@@ -312,17 +312,17 @@ module.exports = class YarnWorkspacesPlugin extends Plugin {
     }
   }
 
-  eachWorkspace(action) {
-    return Promise.all(
-      this.getWorkspaces().map(async (workspaceInfo) => {
-        try {
-          process.chdir(workspaceInfo.root);
-          return await action(workspaceInfo);
-        } finally {
-          process.chdir(this.getContext('root'));
-        }
-      })
-    );
+  async eachWorkspace(action) {
+    let workspaces = this.getWorkspaces();
+
+    for (let workspaceInfo of workspaces) {
+      try {
+        process.chdir(workspaceInfo.root);
+        await action(workspaceInfo);
+      } finally {
+        process.chdir(this.getContext('root'));
+      }
+    }
   }
 
   getWorkspaces() {


### PR DESCRIPTION
Specifically:

* first publish is attempted without `--otp`
* once the "one-time password" error is thrown the user is prompted for the OTP
* once entered, the OTP is used to publish the previously failed package again and to publish all future packages

Also fixes a fairly gnarly issue with `this.eachWorkspace` (ensuring it runs serially vs in parallel, due to `process.chdir`).