### PR TITLE
Prompt if publishing scoped package fails with private error.

### DIFF
--- a/__tests__/plugin-test.js
+++ b/__tests__/plugin-test.js
@@ -253,6 +253,66 @@ describe('release-it-yarn-workspaces', () => {
       });
     });
 
+    it('prompts to ask if the package should be public when private package publishing fails', async () => {
+      setupProject(['packages/@scope-name/*']);
+      setupWorkspace({ name: '@scope-name/bar' });
+      setupWorkspace({ name: '@scope-name/foo' });
+
+      let plugin = buildPlugin();
+
+      plugin.commandResponses['packages/@scope-name/bar'] = {
+        'npm publish . --tag latest': [
+          {
+            reject: true,
+            value:
+              'Payment Required - PUT https://registry.npmjs.org/@scope-name/bar - You must sign up for private packages',
+          },
+        ],
+      };
+
+      plugin.promptResponses['packages/@scope-name/bar'] = {
+        'publish-as-public': true,
+      };
+
+      await runTasks(plugin);
+
+      expect(plugin.commands).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "command": "npm ping --registry https://registry.npmjs.org",
+            "options": Object {},
+            "relativeRoot": "",
+          },
+          Object {
+            "command": "npm whoami --registry https://registry.npmjs.org",
+            "options": Object {},
+            "relativeRoot": "",
+          },
+          Object {
+            "command": "npm publish . --tag latest",
+            "options": Object {
+              "write": false,
+            },
+            "relativeRoot": "packages/@scope-name/bar",
+          },
+          Object {
+            "command": "npm publish . --tag latest --access public",
+            "options": Object {
+              "write": false,
+            },
+            "relativeRoot": "packages/@scope-name/bar",
+          },
+          Object {
+            "command": "npm publish . --tag latest",
+            "options": Object {
+              "write": false,
+            },
+            "relativeRoot": "packages/@scope-name/foo",
+          },
+        ]
+      `);
+    });
+
     it('can specify custom workspaces (overrides package.json settings)', async () => {
       function setupDistWorkspace(_pkg) {
         let pkg = Object.assign(

--- a/__tests__/plugin-test.js
+++ b/__tests__/plugin-test.js
@@ -107,15 +107,29 @@ describe('release-it-yarn-workspaces', () => {
       },
       _pkg
     );
-    let name = pkg.name;
 
-    dir.write({
-      packages: {
-        [name]: {
-          'package.json': json(pkg),
+    let hasScope = pkg.name.startsWith('@');
+    if (hasScope) {
+      let [scope, name] = pkg.name.split('/');
+
+      dir.write({
+        packages: {
+          [scope]: {
+            [name]: {
+              'package.json': json(pkg),
+            },
+          },
         },
-      },
-    });
+      });
+    } else {
+      dir.write({
+        packages: {
+          [pkg.name]: {
+            'package.json': json(pkg),
+          },
+        },
+      });
+    }
   }
 
   function readWorkspacePackage(name) {


### PR DESCRIPTION
Publishing a scoped package defaults to `--access private` on the NPM registry for new packages (unless the package has setup a `publishConfig` property to indicate public access).

This commit detects that specific failure and prompts the user to see if they really meant to publish it as a public package. There is no default value for the confirmation prompt (meaning you **must** answer either "Yes" or "No") in order to avoid an accidental private information leak.