### PR TITLE
Pass specific package paths to `npm publish` (avoid `process.chdir`).

### DIFF
--- a/index.js
+++ b/index.js
@@ -298,9 +298,12 @@ module.exports = class YarnWorkspacesPlugin extends Plugin {
     }
 
     try {
-      await this.exec(`npm publish . --tag ${tag}${accessArg}${otpArg}${dryRunArg}`, {
-        options,
-      });
+      await this.exec(
+        `npm publish ${workspaceInfo.relativeRoot} --tag ${tag}${accessArg}${otpArg}${dryRunArg}`,
+        {
+          options,
+        }
+      );
 
       workspaceInfo.isReleased = true;
     } catch (err) {
@@ -347,11 +350,8 @@ module.exports = class YarnWorkspacesPlugin extends Plugin {
           currentPackage: workspaceInfo,
         });
 
-        process.chdir(workspaceInfo.root);
         await action(workspaceInfo);
       } finally {
-        process.chdir(this.getContext('root'));
-
         this.setContext({
           currentPackage: null,
         });


### PR DESCRIPTION
This _may_ help with #21, but either way it is a nice bit of cleanup.