### PR TITLE
Add logging output (primarily for `--dry-run` / `--verbose`).

### DIFF
--- a/__tests__/plugin-test.js
+++ b/__tests__/plugin-test.js
@@ -858,23 +858,14 @@ describe('release-it-yarn-workspaces', () => {
     });
   });
 
-  describe('_updateDependencies', () => {
+  describe('_buildReplacementDepencencyVersion', () => {
     function updatesTo({ existing, new: newVersion, expected }) {
       it(`updates ${existing} to ${newVersion}`, () => {
         setupProject(['packages/*']);
 
-        setupWorkspace({ name: 'foo' });
-        setupWorkspace({ name: 'bar' });
-
         let plugin = buildPlugin();
 
-        let dependencies = {
-          foo: existing,
-        };
-
-        plugin._updateDependencies(dependencies, newVersion);
-
-        expect(dependencies.foo).toEqual(expected);
+        expect(plugin._buildReplacementDepencencyVersion(existing, newVersion)).toEqual(expected);
       });
     }
 


### PR DESCRIPTION
Example output from glimmerjs/glimmer.js:

```
! Processing packages/@glimmer/blueprint/package.json
!       version: -> 2.0.0-beta.4 (from 2.0.0-beta.3)
! Processing packages/@glimmer/component/package.json
!       version: -> 2.0.0-beta.4 (from 2.0.0-beta.3)
!       dependencies: `@glimmer/core` -> 2.0.0-beta.4 (from 2.0.0-beta.3)
!       devDependencies: `@glimmer/tracking` -> 2.0.0-beta.4 (from 2.0.0-beta.3)
! Processing packages/@glimmer/core/package.json
!       version: -> 2.0.0-beta.4 (from 2.0.0-beta.3)
!       devDependencies: `@glimmer/component` -> 2.0.0-beta.4 (from 2.0.0-beta.3)
!       devDependencies: `@glimmer/tracking` -> 2.0.0-beta.4 (from 2.0.0-beta.3)
! Processing packages/@glimmer/helper/package.json
!       version: -> 2.0.0-beta.4 (from 2.0.0-beta.3)
!       dependencies: `@glimmer/component` -> 2.0.0-beta.4 (from 2.0.0-beta.3)
!       dependencies: `@glimmer/core` -> 2.0.0-beta.4 (from 2.0.0-beta.3)
! Processing packages/@glimmer/modifier/package.json
!       version: -> 2.0.0-beta.4 (from 2.0.0-beta.3)
! Processing packages/@glimmer/ssr/package.json
!       version: -> 2.0.0-beta.4 (from 2.0.0-beta.3)
!       dependencies: `@glimmer/core` -> 2.0.0-beta.4 (from 2.0.0-beta.3)
!       devDependencies: `@glimmer/component` -> 2.0.0-beta.4 (from 2.0.0-beta.3)
! Processing packages/@glimmer/tracking/package.json
!       version: -> 2.0.0-beta.4 (from 2.0.0-beta.3)
! Processing packages/babel-plugins/@glimmer/babel-plugin-glimmer-env/package.json
!       version: -> 2.0.0-beta.4 (from 2.0.0-beta.3)
! Processing packages/babel-plugins/@glimmer/babel-plugin-strict-template-precompile/package.json
!       version: -> 2.0.0-beta.4 (from 2.0.0-beta.3)
! Processing additionManifest.dependencyUpdates for packages/@glimmer/blueprint/files/package.json:
!       devDependencies: `@glimmer/babel-plugin-glimmer-env` -> ~2.0.0-beta.4 (from ~2.0.0-beta.3)
!       devDependencies: `@glimmer/babel-plugin-strict-template-precompile` -> ~2.0.0-beta.4 (from ~2.0.0-beta.3)
!       devDependencies: `@glimmer/blueprint` -> ~2.0.0-beta.4 (from ~2.0.0-beta.3)
!       devDependencies: `@glimmer/component` -> ~2.0.0-beta.4 (from ~2.0.0-beta.3)
!       devDependencies: `@glimmer/core` -> ~2.0.0-beta.4 (from ~2.0.0-beta.3)
!       devDependencies: `@glimmer/helper` -> ~2.0.0-beta.4 (from ~2.0.0-beta.3)
!       devDependencies: `@glimmer/modifier` -> ~2.0.0-beta.4 (from ~2.0.0-beta.3)
```