### PR TITLE
Ensure dependencyUpdates and versionUpdates can reference the same file.

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ function findAdditionalManifests(root, manifestPaths) {
 
   let manifests = packageJSONFiles.map((file) => {
     let absolutePath = path.join(root, file);
-    let pkgInfo = new JSONFile(absolutePath);
+    let pkgInfo = JSONFile.for(absolutePath);
 
     let relativeRoot = path.dirname(file);
 
@@ -71,7 +71,20 @@ function findAdditionalManifests(root, manifestPaths) {
   return manifests;
 }
 
+const jsonFiles = new Map();
+
 class JSONFile {
+  static for(path) {
+    if (jsonFiles.has(path)) {
+      return jsonFiles.get(path);
+    }
+
+    let jsonFile = new this(path);
+    jsonFiles.set(path, jsonFile);
+
+    return jsonFile;
+  }
+
   constructor(filename) {
     let contents = fs.readFileSync(filename, { encoding: 'utf8' });
 
@@ -472,7 +485,7 @@ module.exports = class YarnWorkspacesPlugin extends Plugin {
 
     this._workspaces = packageJSONFiles.map((file) => {
       let absolutePath = path.join(root, file);
-      let pkgInfo = new JSONFile(absolutePath);
+      let pkgInfo = JSONFile.for(absolutePath);
 
       let relativeRoot = path.dirname(file);
 


### PR DESCRIPTION
Prior to these changes, having the same `package.json` referenced in `additionalManifests.dependencyUpdates` and `additionalManifests.versionUpdates` would not work properly. The race condition that caused the underlying issue can be seen here:

1. parse config, find `additionalManifests.dependencyUpdates` and `additionalManifests.versionUpdates`
2. create an instance of `JSONFile` (which abstracts away EOL / indentation issues / etc) for each file (**NOTE** there will now be two `JSONFile` instances with the original file contents in their `pkgInfo.pkg` field)
3. loop through the `additionalManifests.dependencyUpdates` do the dependency updates, write the manifests to disk
4. loop through the `additionalManifests.versionUpdates` do the version bump, write hte manifests to disk

Both the `JSONFile` instances referenced the same file and source `package.json` contents, but the "last one wins" (due to it clobbering the previous update from Step 3 when it saves in Step 4).

This fixes the underlying issue by using a single `JSONFile` instance per manifest file, so that each `.write()` invocation is writing the full content updates.