### PR TITLE
Update the top level `package.json` version by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ interface ReleaseItYarnWorkSpacesConfiguration {
     /**
       An array of `package.json` files that should have their `version`
       property updated to the newly released version.
+
+      Defaults to `['package.json']`.
     */
     versionUpdates?: string[];
 
@@ -213,12 +215,15 @@ you may publish an alternate `docs.json` file in your published package.
     "plugins": {
       "release-it-yarn-workspaces": {
         "additionalManifests": {
-          "dependencyUpdates": ["dist/docs.json"]
+          "versionUpdates": ["dist/docs.json"]
       }
     }
   }
 }
 ```
+
+The default configuration is `['package.json']` to ensure that the top level
+`package.json`s version is updated upon release.
 
 #### dependencyUpdates
 

--- a/__tests__/plugin-test.js
+++ b/__tests__/plugin-test.js
@@ -231,6 +231,7 @@ describe('release-it-yarn-workspaces', () => {
         ]
       `);
 
+      expect(JSON.parse(dir.readText('package.json')).version).toEqual('1.0.1');
       expect(readWorkspacePackage('bar').version).toEqual('1.0.1');
       expect(readWorkspacePackage('foo').version).toEqual('1.0.1');
     });

--- a/index.js
+++ b/index.js
@@ -459,12 +459,20 @@ module.exports = class YarnWorkspacesPlugin extends Plugin {
       versionUpdates: null,
     };
 
-    if (additionalManifestsConfig) {
-      let { dependencyUpdates, versionUpdates } = additionalManifestsConfig;
+    let versionUpdates = ['package.json'];
 
-      additionalManifests.versionUpdates = findAdditionalManifests(root, versionUpdates);
-      additionalManifests.dependencyUpdates = findAdditionalManifests(root, dependencyUpdates);
+    if (additionalManifestsConfig) {
+      additionalManifests.dependencyUpdates = findAdditionalManifests(
+        root,
+        additionalManifestsConfig.dependencyUpdates
+      );
+
+      if (additionalManifestsConfig.versionUpdates) {
+        versionUpdates = additionalManifestsConfig.versionUpdates;
+      }
     }
+
+    additionalManifests.versionUpdates = findAdditionalManifests(root, versionUpdates);
 
     this._additionalManifests = additionalManifests;
 


### PR DESCRIPTION
This ensures that the top level `package.json` file's version is updated when releasing.

In order to opt out of this, you would need to use the following configuration:

```json
{
  "release-it": {
    "plugins": {
      "release-it-yarn-workspaces": {
        "additionalManifests": {
          "versionUpdates": []
        }
      }
    }
  }
}
```