### PR TITLE
Use yarn instead of npm to publish

### DIFF
--- a/__tests__/plugin-test.js
+++ b/__tests__/plugin-test.js
@@ -203,14 +203,14 @@ describe('release-it-yarn-workspaces', () => {
             "options": Object {},
           },
           Object {
-            "command": "npm publish packages/bar --tag latest",
+            "command": "yarn publish packages/bar --tag latest",
             "operationType": "command",
             "options": Object {
               "write": false,
             },
           },
           Object {
-            "command": "npm publish packages/foo --tag latest",
+            "command": "yarn publish packages/foo --tag latest",
             "operationType": "command",
             "options": Object {
               "write": false,
@@ -368,7 +368,7 @@ describe('release-it-yarn-workspaces', () => {
 
       let plugin = buildPlugin();
 
-      plugin.commandResponses['npm publish packages/@scope-name/bar --tag latest'] = [
+      plugin.commandResponses['yarn publish packages/@scope-name/bar --tag latest'] = [
         {
           reject: true,
           value:
@@ -395,21 +395,21 @@ describe('release-it-yarn-workspaces', () => {
             "options": Object {},
           },
           Object {
-            "command": "npm publish packages/@scope-name/bar --tag latest",
+            "command": "yarn publish packages/@scope-name/bar --tag latest",
             "operationType": "command",
             "options": Object {
               "write": false,
             },
           },
           Object {
-            "command": "npm publish packages/@scope-name/bar --tag latest --access public",
+            "command": "yarn publish packages/@scope-name/bar --tag latest --access public",
             "operationType": "command",
             "options": Object {
               "write": false,
             },
           },
           Object {
-            "command": "npm publish packages/@scope-name/foo --tag latest",
+            "command": "yarn publish packages/@scope-name/foo --tag latest",
             "operationType": "command",
             "options": Object {
               "write": false,
@@ -473,14 +473,14 @@ describe('release-it-yarn-workspaces', () => {
             "options": Object {},
           },
           Object {
-            "command": "npm publish dist/packages/qux --tag latest",
+            "command": "yarn publish dist/packages/qux --tag latest",
             "operationType": "command",
             "options": Object {
               "write": false,
             },
           },
           Object {
-            "command": "npm publish dist/packages/zorp --tag latest",
+            "command": "yarn publish dist/packages/zorp --tag latest",
             "operationType": "command",
             "options": Object {
               "write": false,
@@ -520,14 +520,14 @@ describe('release-it-yarn-workspaces', () => {
             "options": Object {},
           },
           Object {
-            "command": "npm publish packages/bar --tag foo",
+            "command": "yarn publish packages/bar --tag foo",
             "operationType": "command",
             "options": Object {
               "write": false,
             },
           },
           Object {
-            "command": "npm publish packages/foo --tag foo",
+            "command": "yarn publish packages/foo --tag foo",
             "operationType": "command",
             "options": Object {
               "write": false,
@@ -557,14 +557,14 @@ describe('release-it-yarn-workspaces', () => {
       expect(plugin.operations).toMatchInlineSnapshot(`
         Array [
           Object {
-            "command": "npm publish packages/bar --tag latest",
+            "command": "yarn publish packages/bar --tag latest",
             "operationType": "command",
             "options": Object {
               "write": false,
             },
           },
           Object {
-            "command": "npm publish packages/foo --tag latest",
+            "command": "yarn publish packages/foo --tag latest",
             "operationType": "command",
             "options": Object {
               "write": false,
@@ -606,14 +606,14 @@ describe('release-it-yarn-workspaces', () => {
             "options": Object {},
           },
           Object {
-            "command": "npm publish packages/bar --tag beta",
+            "command": "yarn publish packages/bar --tag beta",
             "operationType": "command",
             "options": Object {
               "write": false,
             },
           },
           Object {
-            "command": "npm publish packages/foo --tag beta",
+            "command": "yarn publish packages/foo --tag beta",
             "operationType": "command",
             "options": Object {
               "write": false,
@@ -639,7 +639,7 @@ describe('release-it-yarn-workspaces', () => {
       let plugin = buildPlugin();
 
       plugin.commandResponses['packages/bar'] = {
-        'npm publish . --tag latest': [
+        'yarn publish . --tag latest': [
           {
             reject: true,
             value: 'This operation requires a one-time password',
@@ -666,14 +666,14 @@ describe('release-it-yarn-workspaces', () => {
             "options": Object {},
           },
           Object {
-            "command": "npm publish packages/bar --tag latest",
+            "command": "yarn publish packages/bar --tag latest",
             "operationType": "command",
             "options": Object {
               "write": false,
             },
           },
           Object {
-            "command": "npm publish packages/foo --tag latest",
+            "command": "yarn publish packages/foo --tag latest",
             "operationType": "command",
             "options": Object {
               "write": false,
@@ -773,14 +773,14 @@ describe('release-it-yarn-workspaces', () => {
             "options": Object {},
           },
           Object {
-            "command": "npm publish dist/@glimmer/interfaces --tag latest",
+            "command": "yarn publish dist/@glimmer/interfaces --tag latest",
             "operationType": "command",
             "options": Object {
               "write": false,
             },
           },
           Object {
-            "command": "npm publish dist/@glimmer/runtime --tag latest",
+            "command": "yarn publish dist/@glimmer/runtime --tag latest",
             "operationType": "command",
             "options": Object {
               "write": false,

--- a/index.js
+++ b/index.js
@@ -277,7 +277,7 @@ module.exports = class YarnWorkspacesPlugin extends Plugin {
       });
     };
 
-    await this.step({ task, label: 'npm publish', prompt: 'publish' });
+    await this.step({ task, label: 'yarn publish', prompt: 'publish' });
   }
 
   async afterRelease() {
@@ -404,7 +404,7 @@ module.exports = class YarnWorkspacesPlugin extends Plugin {
 
     try {
       await this.exec(
-        `npm publish ${workspaceInfo.relativeRoot} --tag ${tag}${accessArg}${otpArg}${dryRunArg}`,
+        `yarn publish ${workspaceInfo.relativeRoot} --tag ${tag}${accessArg}${otpArg}${dryRunArg}`,
         {
           options,
         }


### PR DESCRIPTION
# Issue
Running npm publish in the workspace root attempts to publish packages on npm by folder name.
E.g. a folder named `package` with package.json `name: 'different-package'` is published to npm as `package`.
`yarn publish` does not have this problem. And since this is for yarn workspaces I see no reason to use npm.

# Solution
Simply replace `npm publish` with `yarn publish`.