### PR TITLE
Support independent workspaces

### DIFF
--- a/__tests__/plugin-test.js
+++ b/__tests__/plugin-test.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const { createTempDir } = require('broccoli-test-helper');
 const { factory, runTasks } = require('release-it/test/util');
 const Shell = require('release-it/lib/shell');
-const Plugin = require('../index');
+const Plugin = require('../src/index');
 
 const namespace = 'release-it-yarn-workspaces';
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "lint:js": "eslint .",
     "test": "npm-run-all lint:js test:jest",
-    "test:jest": "jest"
+    "test:jest": "jest",
+    "debug": "node --inspect-brk ./node_modules/.bin/jest --runInBand"
   },
   "husky": {
     "hooks": {
@@ -29,6 +30,7 @@
     "*.js": "eslint"
   },
   "dependencies": {
+    "chalk": "^4.1.2",
     "detect-indent": "^6.0.0",
     "detect-newline": "^3.1.0",
     "semver": "^7.1.3",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   "repository": "https://github.com/rwjblue/release-it-yarn-workspaces",
   "license": "MIT",
   "author": "Robert Jackson <me@rwjblue.com>",
-  "main": "index.js",
+  "main": "src/index.js",
   "files": [
-    "index.js"
+    "src/*.js"
   ],
   "scripts": {
     "lint:js": "eslint .",

--- a/src/json-file.js
+++ b/src/json-file.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const detectNewline = require('detect-newline');
+const detectIndent = require('detect-indent');
+
+const DETECT_TRAILING_WHITESPACE = /\s+$/;
+
+const jsonFiles = new Map();
+
+module.exports = class JSONFile {
+  static for(path) {
+    if (jsonFiles.has(path)) {
+      return jsonFiles.get(path);
+    }
+
+    let jsonFile = new this(path);
+    jsonFiles.set(path, jsonFile);
+
+    return jsonFile;
+  }
+
+  constructor(filename) {
+    let contents = fs.readFileSync(filename, { encoding: 'utf8' });
+
+    this.filename = filename;
+    this.pkg = JSON.parse(contents);
+    this.lineEndings = detectNewline(contents);
+    this.indent = detectIndent(contents).amount;
+
+    let trailingWhitespace = DETECT_TRAILING_WHITESPACE.exec(contents);
+    this.trailingWhitespace = trailingWhitespace ? trailingWhitespace : '';
+  }
+
+  write() {
+    let contents = JSON.stringify(this.pkg, null, this.indent).replace(/\n/g, this.lineEndings);
+
+    fs.writeFileSync(this.filename, contents + this.trailingWhitespace, { encoding: 'utf8' });
+  }
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,13 @@
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function rejectAfter(ms, error) {
+  await sleep(ms);
+
+  throw error;
+}
+
+module.exports = {
+  rejectAfter,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1337,6 +1337,14 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"


### PR DESCRIPTION
Fixes https://github.com/rwjblue/release-it-yarn-workspaces/issues/40

When specified in package.json "independentWorkspaces" option, prompt to
ask for version the workspace should be updated to.

TODO:
- semver choices before asking text input
- figure out CI
- distTag for independent workspaces
- per workspace changelog generation?

<details>
<summary>Example output</summary>

```sh
❯ yarn release-it --dry-run
yarn run v1.22.10
$ /Users/xwang5/Code/fb/ember-cli-fastboot/node_modules/.bin/release-it --dry-run
$ git describe --tags --abbrev=0
$ /Users/xwang5/Code/fb/ember-cli-fastboot/node_modules/lerna-changelog/bin/cli.js --next-version=Unreleased --from=v3.2.0-beta.2
! npm ping --registry https://registry.npmjs.org
! npm whoami --registry https://registry.npmjs.org
$ git diff --quiet HEAD
$ git rev-parse --abbrev-ref HEAD
$ git config --get branch.master.remote
$ git remote get-url origin
! git fetch
$ git describe --tags --abbrev=0  [cached]
$ git symbolic-ref HEAD
$ git for-each-ref --format="%(upstream:short)" refs/heads/master
$ git rev-parse --abbrev-ref HEAD  [cached]
$ git config --get branch.master.remote  [cached]
$ git remote get-url origin  [cached]
! git fetch
$ git describe --tags --abbrev=0  [cached]

🚀 Let's release ember-cli-fastboot (currently at 3.2.0-beta.2)


Changelog:
## Unreleased (2021-08-02)
#### :boom: Breaking Change
* `ember-cli-fastboot`, `fastboot-app-server`, `fastboot-express-middleware`, `fastboot`
  * [#834](https://github.com/ember-fastboot/ember-cli-fastboot/pull/834) Update using ember-cli-update and drop support for Node 10 ([@mansona](https://github.com/mansona))
* `ember-cli-fastboot`
  * [#825](https://github.com/ember-fastboot/ember-cli-fastboot/pull/825) Drop module unification support ([@xg-wang](https://github.com/xg-wang))
  * [#820](https://github.com/ember-fastboot/ember-cli-fastboot/pull/820) Remove deprecated features for ember-cli-fastboot v3 release ([@xg-wang](https://github.com/xg-wang))
#### :rocket: Enhancement
* `ember-cli-fastboot`
  * [#814](https://github.com/ember-fastboot/ember-cli-fastboot/pull/814) Throw a helpful error when people use `isFastboot` instead of `isFastBoot` ([@bertdeblock](https://github.com/bertdeblock))
* `fastboot-app-server`
  * [#811](https://github.com/ember-fastboot/ember-cli-fastboot/pull/811) [fastboot-app-server] turn on gzip by default ([@xg-wang](https://github.com/xg-wang))
#### :memo: Documentation
* [#810](https://github.com/ember-fastboot/ember-cli-fastboot/pull/810) doc: update CONTRIBUTING.md for code structure and tests ([@xg-wang](https://github.com/xg-wang))
#### :house: Internal
* `ember-cli-fastboot`, `fastboot-app-server`, `fastboot-express-middleware`, `fastboot`
  * [#821](https://github.com/ember-fastboot/ember-cli-fastboot/pull/821) Convert co to async in test; cleanup some configurations ([@xg-wang](https://github.com/xg-wang))
#### Committers: 5
- Ankush Dharkar ([@ankushdharkar](https://github.com/ankushdharkar))
- Bert De Block ([@bertdeblock](https://github.com/bertdeblock))
- Chris Manson ([@mansona](https://github.com/mansona))
- Dave Laird ([@kiwiupover](https://github.com/kiwiupover))
- Thomas Wang ([@xg-wang](https://github.com/xg-wang))

? Select increment (next version): patch (3.2.0)
? Please enter a valid version for the independent fastboot-app-server, from 3.2.0-beta.2: 3.2.0-beta.3
$ Processing packages/ember-cli-fastboot/package.json:
$ 	version: -> 3.2.0 (from 3.2.0-beta.2)
$ 	dependencies: `fastboot` -> 3.2.0 (from 3.2.0-beta.2)
$ 	dependencies: `fastboot-express-middleware` -> 3.2.0 (from 3.2.0-beta.2)
$ Processing packages/fastboot-app-server/package.json:
$ 	version: -> 3.2.0-beta.3 (from 3.2.0-beta.2)
$ 	dependencies: `fastboot` -> 3.2.0 (from 3.2.0-beta.2)
$ 	dependencies: `fastboot-express-middleware` -> 3.2.0 (from 3.2.0-beta.2)
$ Processing packages/fastboot-express-middleware/package.json:
$ 	version: -> 3.2.0 (from 3.2.0-beta.2)
$ 	dependencies: `fastboot` -> 3.2.0 (from 3.2.0-beta.2)
$ Processing packages/fastboot/package.json:
$ 	version: -> 3.2.0 (from 3.2.0-beta.2)
$ Processing additionManifest.dependencyUpdates for ./package.json:
$ Processing additionManifest.dependencyUpdates for test-packages/basic-app/package.json:
$ 	devDependencies: `ember-cli-fastboot` -> 3.2.0 (from 3.2.0-beta.2)
$ Processing additionManifest.dependencyUpdates for test-packages/custom-fastboot-app/package.json:
$ 	devDependencies: `ember-cli-fastboot` -> 3.2.0 (from 3.2.0-beta.2)
$ Processing additionManifest.dependencyUpdates for test-packages/custom-sandbox-app/package.json:
$ 	devDependencies: `ember-cli-fastboot` -> 3.2.0 (from 3.2.0-beta.2)
$ Processing additionManifest.dependencyUpdates for test-packages/ember-cli-fastboot-testing-app/package.json:
$ 	devDependencies: `ember-cli-fastboot` -> 3.2.0 (from 3.2.0-beta.2)
$ Processing additionManifest.dependencyUpdates for test-packages/example-addon/package.json:
$ Processing additionManifest.dependencyUpdates for test-packages/fake-addon-2/package.json:
$ Processing additionManifest.dependencyUpdates for test-packages/fake-addon/package.json:
$ Processing additionManifest.dependencyUpdates for test-packages/hot-swap-app/package.json:
$ 	devDependencies: `ember-cli-fastboot` -> 3.2.0 (from 3.2.0-beta.2)
$ Processing additionManifest.dependencyUpdates for test-packages/integration-tests/package.json:
$ 	devDependencies: `ember-cli-fastboot` -> 3.2.0 (from 3.2.0-beta.2)
$ 	devDependencies: `fastboot` -> 3.2.0 (from 3.2.0-beta.2)
$ Processing additionManifest.versionUpdates for ./package.json:
$ 	version: -> 3.2.0 (from 3.2.0-beta.2)
! Prepending CHANGELOG.md with release notes.
$ git status --short --untracked-files=no

Empty changeset

! git add . --update
? Commit (Release 3.2.0)? (Y/n) 
```

</details>